### PR TITLE
Fixing typo in line 62

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -59,7 +59,7 @@ def signup_for_activity(activity_name: str, email: str):
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
+    # Get the specific activity 
     activity = activities[activity_name]
 
     # Add student


### PR DESCRIPTION
Running through the exercises and noticed a typo.

![Image](https://github.com/user-attachments/assets/36e27acd-7643-4826-8fbd-1c5c21fe92bb)

Steps to Reproduce:
- Navigate to [](https://github.com/skills/getting-started-with-github-copilot/blob/84fdf7e3fd6dd28f875decddc7459d7286e737d8/src/app.py#L62).
- Locate the phrase ["# Get the specificy activity"].
- The intended correction is ["# Get the specific activity"].

Thanks.